### PR TITLE
Spring Security 5 Github OAuth2 solution

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,12 +31,6 @@
 				<type>pom</type>
 				<scope>import</scope>
 			</dependency>
-			<!-- We need to align the Hibernate versions -->
-			<dependency>
-				<groupId>org.hibernate</groupId>
-				<artifactId>hibernate-entitymanager</artifactId>
-				<version>${hibernate-version}</version>
-			</dependency>
 
 			<!-- Swagger -->
 			<dependency>
@@ -133,11 +127,25 @@
 			<groupId>org.apache.camel.springboot</groupId>
 			<artifactId>camel-spring-boot-starter</artifactId>
 		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-security</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.security</groupId>
+			<artifactId>spring-security-oauth2-client</artifactId>
+		</dependency>
+
 
 		<!-- Camel -->
 		<dependency>
 			<groupId>org.apache.camel</groupId>
 			<artifactId>camel-velocity</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.camel</groupId>
+			<artifactId>camel-spring-security</artifactId>
 		</dependency>
 
 		<dependency>
@@ -226,14 +234,14 @@
 					<target>11</target>
 				</configuration>
 			</plugin>
-        <plugin>
-            <artifactId>maven-surefire-plugin</artifactId>
-            <version>2.22.2</version>
-        </plugin>
-        <plugin>
-            <artifactId>maven-failsafe-plugin</artifactId>
-            <version>2.22.2</version>
-        </plugin>
+			<plugin>
+				<artifactId>maven-surefire-plugin</artifactId>
+				<version>2.22.2</version>
+			</plugin>
+			<plugin>
+				<artifactId>maven-failsafe-plugin</artifactId>
+				<version>2.22.2</version>
+			</plugin>
 		</plugins>
 	</build>
 </project>

--- a/src/main/java/com/waracle/cakes/config/CakesConfiguration.java
+++ b/src/main/java/com/waracle/cakes/config/CakesConfiguration.java
@@ -4,9 +4,11 @@ import org.apache.camel.component.jackson.JacksonDataFormat;
 import org.modelmapper.ModelMapper;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
 
 import com.waracle.cakes.model.dto.CakeDTO;
 
+@Profile("prod")
 @Configuration
 public class CakesConfiguration {
 	

--- a/src/main/java/com/waracle/cakes/config/SecurityConfig.java
+++ b/src/main/java/com/waracle/cakes/config/SecurityConfig.java
@@ -1,0 +1,19 @@
+package com.waracle.cakes.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+
+@Profile("prod")
+@Configuration
+public class SecurityConfig extends WebSecurityConfigurerAdapter {
+
+    @Override
+    protected void configure(HttpSecurity http) throws Exception {
+        http.authorizeRequests()
+         .anyRequest().authenticated()
+         .and()
+         .oauth2Login();
+    }
+}

--- a/src/test/java/com/waracle/cakes/config/SecurityConfig.java
+++ b/src/test/java/com/waracle/cakes/config/SecurityConfig.java
@@ -1,0 +1,18 @@
+package com.waracle.cakes.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import org.springframework.security.config.annotation.web.builders.WebSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+
+@Profile("test")
+@Configuration
+public class SecurityConfig extends WebSecurityConfigurerAdapter {
+
+    
+    @Override
+    public void configure(WebSecurity web) throws Exception {
+        web.ignoring().antMatchers("/**");
+    }
+    
+}

--- a/src/test/java/com/waracle/cakes/config/TestConfig.java
+++ b/src/test/java/com/waracle/cakes/config/TestConfig.java
@@ -1,0 +1,27 @@
+package com.waracle.cakes.config;
+
+import org.apache.camel.component.jackson.JacksonDataFormat;
+import org.modelmapper.ModelMapper;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+
+import com.waracle.cakes.model.dto.CakeDTO;
+
+@Profile("test")
+    @Configuration
+    public class TestConfig {
+    	
+    	@Bean
+    	public ModelMapper modelMapper() {
+    		return new ModelMapper();
+    	}
+    	
+    	@Bean
+    	public JacksonDataFormat cakeDtoDataFormat() {
+    		JacksonDataFormat jsonFormat =  new JacksonDataFormat(CakeDTO.class);
+    		jsonFormat.setPrettyPrint(true);
+    		return jsonFormat;
+    	}
+
+    }

--- a/src/test/java/com/waracle/cakes/config/TestSecurityConfig.java
+++ b/src/test/java/com/waracle/cakes/config/TestSecurityConfig.java
@@ -7,7 +7,7 @@ import org.springframework.security.config.annotation.web.configuration.WebSecur
 
 @Profile("test")
 @Configuration
-public class SecurityConfig extends WebSecurityConfigurerAdapter {
+public class TestSecurityConfig extends WebSecurityConfigurerAdapter {
 
     
     @Override

--- a/src/test/java/com/waracle/cakes/e2e/CakeAppTest.java
+++ b/src/test/java/com/waracle/cakes/e2e/CakeAppTest.java
@@ -9,18 +9,23 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 import org.apache.camel.CamelContext;
+import org.apache.camel.component.jackson.JacksonDataFormat;
 import org.apache.camel.test.spring.junit5.CamelSpringBootTest;
 import org.assertj.core.util.Files;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
+import org.modelmapper.ModelMapper;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.core.io.Resource;
@@ -31,11 +36,14 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ActiveProfiles;
+
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.waracle.cakes.model.dto.CakeDTO;
 import com.waracle.cakes.service.CakeService;
 
+@ActiveProfiles("test")
 @CamelSpringBootTest
 @SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
 @DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
@@ -184,9 +192,5 @@ public class CakeAppTest {
         
         assertThat(errorResponse.getStatusCode()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
     }
-    
-    
-
-    
 
 }

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -30,16 +30,14 @@ camel:
   # Spring Data JPA configuration
 spring:
   profiles:
-    active: prod
+    active: test
   jpa:
     database: h2
     database-platform: org.hibernate.dialect.H2Dialect
+  
+logging:
+  level: 
+      root: INFO
+      com.waracle.cakes: DEBUG
+      org.apache.camel: DEBUG
     
-  Security:
-        oauth2:
-            client:
-                registration:
-                    github:
-                       clientId: b70d431814e6d107934d
-                       clientSecret: 9dd51deb2f8a55fe0ee7856176499c882f608281
-                                


### PR DESCRIPTION
Here we have Spring Security 5 OAuth2 out of the box Github solution with additional - security disabled test profile.
There is also config in github Oauth2 Applications settings to register the cake manager application (which handles the redirects and token exchange).

KNOWN ISSUE *
OAuth2 working correctly... but only for a single user within a single session. Any other login attempts result in the below login screen error message. It is a server side issue. It can only be resolved by restarting restarting the application (and clearing old cookies). Issue under investigation. It looks like a local environmental (jvm ssl config level) issue.

[invalid_token_response] An error occurred while attempting to retrieve the OAuth 2.0 Access Token Response: I/O error on POST request for "https://github.com/login/oauth/access_token": Received close_notify during handshake; nested exception is javax.net.ssl.SSLProtocolException: Received close_notify during handshake